### PR TITLE
Ee sidebar

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -21,6 +21,6 @@ sidebar:
 product-family:
   name: BlueXP
   repo: bluexp-family
-  sidebar_label: All BlueXP documentation
+
 
 


### PR DESCRIPTION

the sidebar_label keyword, is now obsolete and must be removed from project files before the end of 2023.